### PR TITLE
Allow for IndexedDB version upgrades.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "yuidocjs": "^0.8.1"
   },
   "dependencies": {
-    "orbit-core": "^0.8.0-beta.4"
+    "orbit-core": "^0.8.0-beta.6"
   }
 }

--- a/src/indexeddb-bucket.js
+++ b/src/indexeddb-bucket.js
@@ -15,20 +15,53 @@ export default class IndexedDBBucket extends Bucket {
    * Create a new IndexedDBBucket.
    *
    * @constructor
-   * @param {Object}  [options]
+   * @param {Object}  [options = {}]
    * @param {String}  [options.name]        Optional. Name of this bucket.
-   * @param {String}  [options.dbName]      Optional. Name of the IndexedDB database. Defaults to 'orbit-bucket'.
-   * @param {String}  [options.dbStoreName] Optional. Name of the store within the database. Defaults to 'data'.
-   * @param {Integer} [options.dbVersion]   Optional. The version to open the IndexedDB database with. IndexedDB's default verions is 1.
+   * @param {String}  [options.namespace]   Optional. Namespace of the bucket. Will be used for the IndexedDB database name. Defaults to 'orbit-bucket'.
+   * @param {String}  [options.storeName]   Optional. Name of the IndexedDB ObjectStore. Defaults to 'data'.
+   * @param {Integer} [options.version]     Optional. The version to open the IndexedDB database with. Defaults to `1`.
    */
   constructor(options = {}) {
     assert('Your browser does not support IndexedDB!', supportsIndexedDB());
 
     super(options);
 
-    this.dbName      = options.dbName || 'orbit-bucket';
-    this.dbStoreName = options.dbStoreName || 'data';
-    this.dbVersion   = options.dbVersion;
+    this._namespace = options.namespace || 'orbit-bucket';
+    this._version   = options.version || 1;
+    this._storeName = options.storeName || 'data';
+  }
+
+  /**
+   * The version to specify when opening the IndexedDB database.
+   *
+   * IndexedDB's default verions is 1.
+   *
+   * @return {Integer} Version number.
+   */
+  get dbVersion() {
+    return this._version;
+  }
+
+  /**
+   * IndexedDB database name.
+   *
+   * Defaults to 'orbit-bucket', which can be overridden in the constructor.
+   *
+   * @return {String} Database name.
+   */
+  get dbName() {
+    return this._namespace;
+  }
+
+  /**
+   * IndexedDB ObjectStore name.
+   *
+   * Defaults to 'settings', which can be overridden in the constructor.
+   *
+   * @return {String} Database name.
+   */
+  get dbStoreName() {
+    return this._storeName;
   }
 
   openDB() {

--- a/src/indexeddb-source.js
+++ b/src/indexeddb-source.js
@@ -20,11 +20,10 @@ export default class IndexedDBSource extends Source {
    * Create a new IndexedDBSource.
    *
    * @constructor
-   * @param {Object}  [options]
-   * @param {Schema}  [options.schema]    Schema for source.
+   * @param {Object}  [options = {}]
+   * @param {Schema}  [options.schema]    Orbit Schema.
    * @param {String}  [options.name]      Optional. Name for source. Defaults to 'indexedDB'.
-   * @param {String}  [options.dbName]    Optional. Name of the IndexedDB database. Defaults to 'orbit'.
-   * @param {Integer} [options.dbVersion] Optional. The version to open the IndexedDB database with. IndexedDB's default verions is 1.
+   * @param {String}  [options.namespace] Optional. Namespace of the application. Will be used for the IndexedDB database name. Defaults to 'orbit'.
    */
   constructor(options = {}) {
     assert('IndexedDBSource\'s `schema` must be specified in `options.schema` constructor argument', options.schema);
@@ -34,8 +33,27 @@ export default class IndexedDBSource extends Source {
 
     super(options);
 
-    this.dbName    = options.dbName || 'orbit';
-    this.dbVersion = options.dbVersion;
+    this._namespace = options.namespace || 'orbit';
+  }
+
+  /**
+   * The version to specify when opening the IndexedDB database.
+   *
+   * @return {Integer} Version number.
+   */
+  get dbVersion() {
+    return this.schema.version;
+  }
+
+  /**
+   * IndexedDB database name.
+   *
+   * Defaults to the namespace of the app, which can be overridden in the constructor.
+   *
+   * @return {String} Database name.
+   */
+  get dbName() {
+    return this._namespace;
   }
 
   openDB() {
@@ -68,9 +86,13 @@ export default class IndexedDBSource extends Source {
 
   createDB(db) {
     Object.keys(this.schema.models).forEach(model => {
-      db.createObjectStore(model, { keyPath: 'id' });
-      // TODO - create indices
+      this.registerModel(db, model);
     });
+  }
+
+  registerModel(db, model) {
+    db.createObjectStore(model, { keyPath: 'id' });
+    // TODO - create indices
   }
 
   deleteDB() {

--- a/src/indexeddb-source.js
+++ b/src/indexeddb-source.js
@@ -34,6 +34,8 @@ export default class IndexedDBSource extends Source {
     super(options);
 
     this._namespace = options.namespace || 'orbit';
+
+    this.schema.on('upgrade', () => this.reopenDB());
   }
 
   /**
@@ -56,6 +58,10 @@ export default class IndexedDBSource extends Source {
     return this._namespace;
   }
 
+  get isDBOpen() {
+    return !!this._db;
+  }
+
   openDB() {
     return new Orbit.Promise((resolve, reject) => {
       if (this._db) {
@@ -64,8 +70,8 @@ export default class IndexedDBSource extends Source {
         let request = self.indexedDB.open(this.dbName, this.dbVersion);
 
         request.onerror = (/* event */) => {
-          console.error('error opening indexedDB', this.dbName);
-          reject(request.errorCode);
+          // console.error('error opening indexedDB', this.dbName);
+          reject(request.error);
         };
 
         request.onsuccess = (/* event */) => {
@@ -77,45 +83,68 @@ export default class IndexedDBSource extends Source {
         request.onupgradeneeded = (event) => {
           // console.log('indexedDB upgrade needed');
           const db = this._db = event.target.result;
-          // TODO - conditionally call migrateDB
-          this.createDB(db);
+          if (event && event.oldVersion > 0) {
+            this.migrateDB(db, event);
+          } else {
+            this.createDB(db);
+          }
         };
       }
     });
   }
 
+  closeDB() {
+    if (this.isDBOpen) {
+      this._db.close();
+      this._db = null;
+    }
+  }
+
+  reopenDB() {
+    this.closeDB();
+    return this.openDB();
+  }
+
   createDB(db) {
+    // console.log('createDB');
     Object.keys(this.schema.models).forEach(model => {
       this.registerModel(db, model);
     });
   }
 
-  registerModel(db, model) {
-    db.createObjectStore(model, { keyPath: 'id' });
-    // TODO - create indices
+  /**
+   * Migrate database.
+   *
+   * @param  {IDBDatabase} db              Database to upgrade.
+   * @param  {IDBVersionChangeEvent} event Event resulting from version change.
+   */
+  migrateDB(db, event) {
+    console.error('IndexedDBSource#migrateDB - should be overridden to upgrade IDBDatabase from: ', event.oldVersion, ' -> ', event.newVersion);
   }
 
   deleteDB() {
+    this.closeDB();
+
     return new Orbit.Promise((resolve, reject) => {
       let request = self.indexedDB.deleteDatabase(this.dbName);
 
       request.onerror = (/* event */) => {
-        console.error('error deleting indexedDB', this.dbName);
-        reject(request.errorCode);
+        // console.error('error deleting indexedDB', this.dbName);
+        reject(request.error);
       };
 
       request.onsuccess = (/* event */) => {
         // console.log('success deleting indexedDB', this.dbName);
-        this._db = null;
         resolve();
       };
     });
   }
 
-  // TODO
-  // migrateDB(db) {
-  //
-  // }
+  registerModel(db, model) {
+    // console.log('registerModel', model);
+    db.createObjectStore(model, { keyPath: 'id' });
+    // TODO - create indices
+  }
 
   getRecord(record) {
     return new Orbit.Promise((resolve, reject) => {
@@ -124,8 +153,8 @@ export default class IndexedDBSource extends Source {
       const request = objectStore.get(record.id);
 
       request.onerror = function(/* event */) {
-        console.error('error - getRecord', request.errorCode);
-        reject(request.errorCode);
+        console.error('error - getRecord', request.error);
+        reject(request.error);
       };
 
       request.onsuccess = function(/* event */) {
@@ -143,8 +172,8 @@ export default class IndexedDBSource extends Source {
       const records = [];
 
       request.onerror = function(/* event */) {
-        console.error('error - getRecords', request.errorCode);
-        reject(request.errorCode);
+        console.error('error - getRecords', request.error);
+        reject(request.error);
       };
 
       request.onsuccess = function(event) {
@@ -179,8 +208,8 @@ export default class IndexedDBSource extends Source {
       const request = objectStore.put(record);
 
       request.onerror = function(/* event */) {
-        console.error('error - putRecord', request.errorCode);
-        reject(request.errorCode);
+        console.error('error - putRecord', request.error);
+        reject(request.error);
       };
 
       request.onsuccess = function(/* event */) {
@@ -197,8 +226,8 @@ export default class IndexedDBSource extends Source {
       const request = objectStore.delete(record.id);
 
       request.onerror = function(/* event */) {
-        console.error('error - removeRecord', request.errorCode);
-        reject(request.errorCode);
+        console.error('error - removeRecord', request.error);
+        reject(request.error);
       };
 
       request.onsuccess = function(/* event */) {
@@ -219,8 +248,8 @@ export default class IndexedDBSource extends Source {
       const request = objectStore.clear();
 
       request.onerror = function(/* event */) {
-        console.error('error - removeRecords', request.errorCode);
-        reject(request.errorCode);
+        console.error('error - removeRecords', request.error);
+        reject(request.error);
       };
 
       request.onsuccess = function(/* event */) {

--- a/test/tests/support/indexeddb.js
+++ b/test/tests/support/indexeddb.js
@@ -1,20 +1,7 @@
 import Orbit from 'orbit';
 
-function openDB(source) {
-  return new Orbit.Promise((resolve, reject) => {
-    let request = self.indexedDB.open(source.dbName, source.dbVersion);
-
-    request.onerror = function(/* event */) {
-      reject(request.errorCode);
-    };
-
-    request.onsuccess = function(/* event */) {
-      resolve(request.result);
-    };
-  });}
-
 function getRecord(source, record) {
-  return openDB(source)
+  return source.openDB()
     .then(db => {
       const transaction = db.transaction([record.type]);
       const objectStore = transaction.objectStore(record.type);
@@ -23,8 +10,8 @@ function getRecord(source, record) {
         const request = objectStore.get(record.id);
 
         request.onerror = function(/* event */) {
-          // console.error('error - getRecord', request.errorCode);
-          reject(request.errorCode);
+          // console.error('error - getRecord', request.error);
+          reject(request.error);
         };
 
         request.onsuccess = function(/* event */) {

--- a/test/tests/unit/indexeddb-bucket-test.js
+++ b/test/tests/unit/indexeddb-bucket-test.js
@@ -18,9 +18,15 @@ module('IndexedDBBucket', function(hooks) {
     assert.ok(bucket instanceof Bucket, 'instanceof Bucket');
   });
 
-  test('is assigned a default dbName and dbStoreName', function(assert) {
+  test('is assigned a default `dbName` and `dbStoreName`', function(assert) {
     assert.equal(bucket.dbName, 'orbit-bucket', '`dbName` is `orbit-bucket` by default');
     assert.equal(bucket.dbStoreName, 'data', '`dbStoreName` is `data` by default');
+  });
+
+  test('can override `dbName` and `dbStoreName` via `namespace` and `storeName` settings', function(assert) {
+    const custom  = new IndexedDBBucket({ namespace: 'orbit-settings', storeName: 'settings' });
+    assert.equal(custom.dbName, 'orbit-settings', '`dbName` has been customized');
+    assert.equal(custom.dbStoreName, 'settings', '`dbStoreName` has been customized');
   });
 
   test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', function(assert) {


### PR DESCRIPTION
For the IndexedDBSource, the DB version is tied to the `version` of the source's associated `Schema`. The source responds to the `upgrade` event on `Schema`, which in turn reopens the DB and calls `migrateDB` to allow for custom migrations.

For the IndexedDBBucket, the DB version is set independently. It can be bumped via a call to `upgrade`, which takes the new `version` as an argument. The bucket reopens the DB and calls `migrateDB` to allow for custom migrations.
